### PR TITLE
Error PHP7

### DIFF
--- a/core/includes/misc/compress.php
+++ b/core/includes/misc/compress.php
@@ -25,6 +25,7 @@
         if (substr_count($_SERVER['HTTP_ACCEPT_ENCODING'], "gzip"))
         {
             ob_start("ob_gzhandler");
+            ob_end_clean();
         }
     }
 


### PR DESCRIPTION
 buffer is not cleaned -> ob_start("ob_gzhandler");
this causes the page not to load
PHP VERSION: 7